### PR TITLE
Fix constraint error exception when Write is called with an empty string

### DIFF
--- a/excel_out.adb
+++ b/excel_out.adb
@@ -1272,7 +1272,7 @@ package body Excel_Out is
   is
     is_valid : Boolean;
   begin
-    if str'Length > 0 and str (str'First) in '=' then
+    if str'Length > 0 and then str (str'First) in '=' then
       Write_as_Formula (xl, r, c, str, 0.0, True, True, is_valid);
       if is_valid then
         return;  --  Formula is valid and has been written.


### PR DESCRIPTION
Replace the 'and' by 'and then' to make sure the test on str'Length is checked before trying to access the string content.

I've discovered the issue when using your Excel library in the Ada-France application. We are using it to export the list of members and communicate with Ada Europe or Ada User Society.